### PR TITLE
chore: update to 0.4.2

### DIFF
--- a/brownie-config.yml
+++ b/brownie-config.yml
@@ -8,7 +8,7 @@ autofetch_sources: True
 
 # require OpenZepplin Contracts
 dependencies:
-  - iearn-finance/yearn-vaults@0.4.0
+  - iearn-finance/yearn-vaults@0.4.1
   - OpenZeppelin/openzeppelin-contracts@3.1.0
 
 # path remapping to support imports from GitHub/NPM
@@ -16,7 +16,7 @@ compiler:
   solc:
     version: 0.6.12
     remappings:
-      - "@yearnvaults=iearn-finance/yearn-vaults@0.4.0"
+      - "@yearnvaults=iearn-finance/yearn-vaults@0.4.1"
       - "@openzeppelin=OpenZeppelin/openzeppelin-contracts@3.1.0"
 
 reports:

--- a/brownie-config.yml
+++ b/brownie-config.yml
@@ -8,7 +8,7 @@ autofetch_sources: True
 
 # require OpenZepplin Contracts
 dependencies:
-  - iearn-finance/yearn-vaults@0.4.1
+  - iearn-finance/yearn-vaults@0.4.2
   - OpenZeppelin/openzeppelin-contracts@3.1.0
 
 # path remapping to support imports from GitHub/NPM
@@ -16,7 +16,7 @@ compiler:
   solc:
     version: 0.6.12
     remappings:
-      - "@yearnvaults=iearn-finance/yearn-vaults@0.4.1"
+      - "@yearnvaults=iearn-finance/yearn-vaults@0.4.2"
       - "@openzeppelin=OpenZeppelin/openzeppelin-contracts@3.1.0"
 
 reports:

--- a/tests/test_affliate.py
+++ b/tests/test_affliate.py
@@ -99,7 +99,7 @@ def test_deposit_max(token, registry, vault, affiliate_token, gov, rando):
 
 
 def test_migrate(token, registry, create_vault, affiliate_token, gov, rando, affiliate):
-    vault1 = create_vault(releaseDelta=1, token=token)
+    vault1 = create_vault(releaseDelta=3, token=token)
     registry.newRelease(vault1, {"from": gov})
     registry.endorseVault(vault1, {"from": gov})
     token.transfer(rando, 10000, {"from": gov})


### PR DESCRIPTION
0.4.0 & 0.4.1 contains breaking API changes that were reverted in 0.4.2, the test should skip these two breaking versions.